### PR TITLE
Fix public API for releases

### DIFF
--- a/public/packages/concrete_cms_releases/src/Api/ApiRouteList.php
+++ b/public/packages/concrete_cms_releases/src/Api/ApiRouteList.php
@@ -6,6 +6,7 @@ use Concrete\Core\Routing\RouteListInterface;
 use Concrete\Core\Routing\Router;
 use Doctrine\DBAL\Connection;
 use PortlandLabs\Concrete\Releases\Api\Controller\ConcreteReleases;
+use PortlandLabs\ConcreteCmsTheme\API\V1\Middleware\FractalNegotiatorMiddleware;
 
 class ApiRouteList implements RouteListInterface
 {
@@ -26,8 +27,12 @@ class ApiRouteList implements RouteListInterface
 
     public function loadRoutes(Router $router)
     {
-        $router->get('/api/1.0/libraries/releases/concretecms', [ConcreteReleases::class, 'getList']);
-        $router->get('/api/1.0/libraries/releases/concretecms/{releaseId}', [ConcreteReleases::class, 'getRelease']);
+        $router->buildGroup()->addMiddleware(FractalNegotiatorMiddleware::class)
+            ->routes( function($router) {
+                $router->get('/api/1.0/libraries/releases/concretecms', [ConcreteReleases::class, 'getList']);
+                $router->get('/api/1.0/libraries/releases/concretecms/{releaseId}', [ConcreteReleases::class, 'getRelease']);
+                $router->get('/api/1.0/libraries/releases/concretecms/getByVersionNumber/{version}', [ConcreteReleases::class, 'getByVersionNumber']);
+            });
     }
 
 }

--- a/public/packages/concrete_cms_releases/src/Api/Controller/ConcreteReleases.php
+++ b/public/packages/concrete_cms_releases/src/Api/Controller/ConcreteReleases.php
@@ -4,6 +4,8 @@ namespace PortlandLabs\Concrete\Releases\Api\Controller;
 
 use Concrete\Core\Api\ApiController;
 use Doctrine\ORM\EntityManager;
+use League\Fractal\Resource\Collection;
+use PortlandLabs\Concrete\Releases\Api\Transformer\ConcreteReleaseTransformer;
 use PortlandLabs\Concrete\Releases\Entity\ConcreteRelease;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Concrete\Core\Http\Request;
@@ -44,12 +46,12 @@ class ConcreteReleases extends ApiController
         usort($releases, function($a, $b) {
             return version_compare($b->getVersionNumber(), $a->getVersionNumber());
         });
-        return new JsonResponse($releases);
+        return new Collection($releases, new ConcreteReleaseTransformer());
     }
 
     /**
      * @OA\Get(
-     *     path="/ccm/api/1.0/libraries/release/concretecms/{releaseId}",
+     *     path="/api/1.0/libraries/releases/concretecms/{releaseId}",
      *     tags={"releases"},
      *     summary="Find a Concrete release by its ID",
      *     @OA\Parameter(
@@ -69,7 +71,36 @@ class ConcreteReleases extends ApiController
     {
         $release = $this->entityManager->find(ConcreteRelease::class, $releaseId);
         if ($release) {
-            return new JsonResponse($release);
+            return $this->transform($release, new ConcreteReleaseTransformer());
+        } else {
+            return $this->error('Release not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/1.0/libraries/releases/concretecms/getByVersionNumber/{version}",
+     *     tags={"releases"},
+     *     summary="Find a Concrete release by its version number",
+     *     @OA\Parameter(
+     *         name="version",
+     *         in="path",
+     *         description="Version number",
+     *         required=true
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful operation",
+     *         @OA\JsonContent(ref="#/components/schemas/ConcreteRelease"),
+     *     ),
+     * )
+     */
+    public function getByVersionNumber(string $version)
+    {
+        $release = $this->entityManager->getRepository(ConcreteRelease::class)
+            ->findOneByVersionNumber($version);
+        if ($release) {
+            return $this->transform($release, new ConcreteReleaseTransformer());
         } else {
             return $this->error('Release not found', 404);
         }

--- a/public/packages/concrete_cms_releases/src/Api/Transformer/ConcreteReleaseTransformer.php
+++ b/public/packages/concrete_cms_releases/src/Api/Transformer/ConcreteReleaseTransformer.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PortlandLabs\Concrete\Releases\Api\Transformer;
+
+use Concrete\Core\Api\Fractal\Transformer\FileTransformer;
+use League\Fractal\Resource\Item;
+use League\Fractal\TransformerAbstract;
+use PortlandLabs\Concrete\Releases\Entity\ConcreteRelease;
+
+class ConcreteReleaseTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'remote_updater_file',
+        'direct_download_file',
+    ];
+
+    protected $defaultIncludes = [
+        'remote_updater_file',
+        'direct_download_file',
+    ];
+
+    public function transform(ConcreteRelease $release)
+    {
+        return [
+            'id' => $release->getId(),
+            'version_number' => $release->getVersionNumber(),
+            'version_name' => $release->getVersionName(),
+            'release_notes' => $release->getReleaseNotes(),
+            'release_notes_url' => $release->getReleaseNotesUrl(),
+            'release_date' => $release->getReleaseDate('Y-m-d'),
+            'md5_sum' => $release->getMd5sum(),
+            'is_available_for_remote_update' => $release->isAvailableForRemoteUpdate(),
+            'is_pre_release' => $release->isPrerelease(),
+        ];
+    }
+
+    public function includeRemoteUpdaterFile(ConcreteRelease $release)
+    {
+        $file = $release->getRemoteUpdaterFile();
+        if ($file) {
+            return new Item($file, new FileTransformer());
+        }
+    }
+
+    public function includeDirectDownloadFile(ConcreteRelease $release)
+    {
+        $file = $release->getDirectDownloadFile();
+        if ($file) {
+            return new Item($file, new FileTransformer());
+        }
+    }
+
+}


### PR DESCRIPTION
The Concrete CMS releases package allows us to offer public versions of Concrete CMS along with a consumable REST API, but there are some issues with how it's built today. This PR

* Fixes some endpoints that weren't uniform
* Ensures that the API response has information we actually need for doing things like downloading the release file
* Uses a new release transformer instead of the jsonSerialize object for better control over what we return. 